### PR TITLE
Option to set datasetID

### DIFF
--- a/preprocessor/preprocessor.go
+++ b/preprocessor/preprocessor.go
@@ -21,6 +21,7 @@ const defaultRecordsBatchSize = 1000
 
 type MetadataPreProcessor struct {
 	IntegrationID    string
+	DatasetID        string
 	InputDirectory   string
 	OutputDirectory  string
 	Pennsieve        *pennsieve.Session
@@ -75,24 +76,31 @@ func FromEnv() (*MetadataPreProcessor, error) {
 	return NewMetadataPreProcessor(integrationID, inputDirectory, outputDirectory, sessionToken, apiHost, api2Host, 0), nil
 }
 
-func (m *MetadataPreProcessor) Run() error {
-	// get integration info
-	integration, err := m.Pennsieve.GetIntegration(m.IntegrationID)
-	if err != nil {
-		return err
-	}
-	datasetID := integration.DatasetNodeID
-	logger.Info("got integration", slog.String("datasetID", datasetID))
+func (m *MetadataPreProcessor) WithDatasetID(datasetID string) *MetadataPreProcessor {
+	m.DatasetID = datasetID
+	return m
+}
 
+func (m *MetadataPreProcessor) Run() error {
+	if len(m.DatasetID) == 0 {
+		// get integration info
+		integration, err := m.Pennsieve.GetIntegration(m.IntegrationID)
+		if err != nil {
+			return err
+		}
+		datasetID := integration.DatasetNodeID
+		logger.Info("got integration", slog.String("datasetID", datasetID))
+		m.DatasetID = datasetID
+	}
 	if err := m.MkDirectories(); err != nil {
 		return err
 	}
 	metadataPath := m.MetadataPath()
-	schemaElements, err := m.WriteGraphSchema(metadataPath, datasetID)
+	schemaElements, err := m.WriteGraphSchema(metadataPath, m.DatasetID)
 	if err != nil {
 		return err
 	}
-	if err := m.WriteInstances(metadataPath, datasetID, schemaElements); err != nil {
+	if err := m.WriteInstances(metadataPath, m.DatasetID, schemaElements); err != nil {
 		return err
 	}
 	return nil

--- a/preprocessor/preprocessor.go
+++ b/preprocessor/preprocessor.go
@@ -84,14 +84,16 @@ func (m *MetadataPreProcessor) WithDatasetID(datasetID string) *MetadataPreProce
 func (m *MetadataPreProcessor) Run() error {
 	if len(m.DatasetID) == 0 {
 		// get integration info
+		logger.Info("looking up integration", slog.String("integrationID", m.IntegrationID))
+
 		integration, err := m.Pennsieve.GetIntegration(m.IntegrationID)
 		if err != nil {
 			return err
 		}
 		datasetID := integration.DatasetNodeID
-		logger.Info("got integration", slog.String("datasetID", datasetID))
 		m.DatasetID = datasetID
 	}
+	logger.Info("getting metadata for dataset", slog.String("datasetID", m.DatasetID))
 	if err := m.MkDirectories(); err != nil {
 		return err
 	}


### PR DESCRIPTION
PR adds option to set the DatasetID manually. 

To be used when this project is used as a library, so if the caller already knows the ID, they can just set it instead of looking up the integration.