### PR TITLE
Create client/datatypes package

### DIFF
--- a/client/models/datatypes/datatypes.go
+++ b/client/models/datatypes/datatypes.go
@@ -1,0 +1,24 @@
+package datatypes
+
+type SimpleType string
+
+const StringType SimpleType = "String"
+const LongType SimpleType = "Long"
+const DoubleType SimpleType = "Double"
+const BooleanType SimpleType = "Boolean"
+const DateType SimpleType = "Date"
+
+type ComplexType string
+
+const ArrayType ComplexType = "array"
+
+type ArrayDataType struct {
+	Type  ComplexType `json:"type"`
+	Items ItemsType   `json:"items"`
+}
+
+type ItemsType struct {
+	Type   SimpleType `json:"type"`
+	Format string     `json:"format,omitempty"`
+	Unit   string     `json:"unit,omitempty"`
+}

--- a/client/models/instance/property.go
+++ b/client/models/instance/property.go
@@ -4,30 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/pennsieve/processor-pre-metadata/client/models/datatypes"
 )
-
-type SimpleType string
-
-const StringType SimpleType = "String"
-const LongType SimpleType = "Long"
-const DoubleType SimpleType = "Double"
-const BooleanType SimpleType = "Boolean"
-const DateType SimpleType = "Date"
-
-type ComplexType string
-
-const ArrayType ComplexType = "array"
-
-type ArrayDataType struct {
-	Type  ComplexType `json:"type"`
-	Items ItemsType   `json:"items"`
-}
-
-type ItemsType struct {
-	Type   SimpleType `json:"type"`
-	Format string     `json:"format,omitempty"`
-	Unit   string     `json:"unit,omitempty"`
-}
 
 type Property struct {
 	ConceptTitle bool `json:"conceptTitle"`
@@ -42,9 +20,9 @@ type Property struct {
 }
 
 func (p Property) DecodeDataType() (any, error) {
-	var simpleType SimpleType
+	var simpleType datatypes.SimpleType
 	if err := json.Unmarshal(p.DataType, &simpleType); err != nil {
-		var arrayType ArrayDataType
+		var arrayType datatypes.ArrayDataType
 		if arrErr := json.Unmarshal(p.DataType, &arrayType); arrErr != nil {
 			return nil, fmt.Errorf("data type %s is not simple or array: %w", p.DataType, errors.Join(err, arrErr))
 		}
@@ -59,13 +37,13 @@ func (p Property) LongValue() (int64, error) {
 		return 0, err
 	}
 	switch dt := dataType.(type) {
-	case SimpleType:
-		if dt == LongType {
+	case datatypes.SimpleType:
+		if dt == datatypes.LongType {
 			return int64(p.Value.(float64)), nil
 		} else {
 			return 0, fmt.Errorf("data type is not Long: %s", dt)
 		}
-	case ArrayDataType:
+	case datatypes.ArrayDataType:
 		return 0, fmt.Errorf("data type is not Long: %T", dt)
 	default:
 		return 0, fmt.Errorf("unknown dataType: %T", dt)
@@ -79,8 +57,8 @@ func (p Property) ArrayValue() (any, error) {
 		return nil, err
 	}
 	switch dt := dataType.(type) {
-	case ArrayDataType:
-		if dt.Type == ArrayType && dt.Items.Type == LongType {
+	case datatypes.ArrayDataType:
+		if dt.Type == datatypes.ArrayType && dt.Items.Type == datatypes.LongType {
 			var longs []int64
 			if p.Value == nil {
 				return longs, nil
@@ -89,18 +67,18 @@ func (p Property) ArrayValue() (any, error) {
 				longs = append(longs, int64(l.(float64)))
 			}
 			return longs, nil
-		} else if dt.Type == ArrayType && dt.Items.Type == StringType {
+		} else if dt.Type == datatypes.ArrayType && dt.Items.Type == datatypes.StringType {
 			return convertArray[string](p.Value), nil
-		} else if dt.Type == ArrayType && dt.Items.Type == DoubleType {
+		} else if dt.Type == datatypes.ArrayType && dt.Items.Type == datatypes.DoubleType {
 			return convertArray[float64](p.Value), nil
-		} else if dt.Type == ArrayType && dt.Items.Type == BooleanType {
+		} else if dt.Type == datatypes.ArrayType && dt.Items.Type == datatypes.BooleanType {
 			return convertArray[bool](p.Value), nil
-		} else if dt.Type == ArrayType && dt.Items.Type == DateType {
+		} else if dt.Type == datatypes.ArrayType && dt.Items.Type == datatypes.DateType {
 			return convertArray[string](p.Value), nil
 		} else {
 			return nil, fmt.Errorf("data type is not array of Longs: %s of %s", dt.Type, dt.Items.Type)
 		}
-	case SimpleType:
+	case datatypes.SimpleType:
 		return nil, fmt.Errorf("data type is not array: %T", dt)
 	default:
 		return nil, fmt.Errorf("unknown dataType: %T", dt)

--- a/client/reader_test.go
+++ b/client/reader_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"github.com/pennsieve/processor-pre-metadata/client/models/datatypes"
 	"github.com/pennsieve/processor-pre-metadata/client/models/instance"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,37 +44,37 @@ func TestReader_GetRecordsForModel(t *testing.T) {
 
 		// Name
 		name := propNameToProp["name"]
-		assertSimpleType(t, instance.StringType, "stone", name)
+		assertSimpleType(t, datatypes.StringType, "stone", name)
 
 		// ID
 		id := propNameToProp["id"]
-		assertSimpleType(t, instance.LongType, int64(1), id)
+		assertSimpleType(t, datatypes.LongType, int64(1), id)
 
 		// Weights
 		weights := propNameToProp["weights"]
-		assertArrayType(t, instance.ArrayDataType{
-			Type:  instance.ArrayType,
-			Items: instance.ItemsType{Type: instance.LongType},
+		assertArrayType(t, datatypes.ArrayDataType{
+			Type:  datatypes.ArrayType,
+			Items: datatypes.ItemsType{Type: datatypes.LongType},
 		}, []int64(nil), weights)
 
 		// Synonyms
 		synonyms := propNameToProp["synonyms"]
-		assertArrayType(t, instance.ArrayDataType{
-			Type:  instance.ArrayType,
-			Items: instance.ItemsType{Type: instance.StringType},
+		assertArrayType(t, datatypes.ArrayDataType{
+			Type:  datatypes.ArrayType,
+			Items: datatypes.ItemsType{Type: datatypes.StringType},
 		}, []string(nil), synonyms)
 
 		// GPA
 		gpa := propNameToProp["gpa"]
-		assertSimpleType(t, instance.DoubleType, nil, gpa)
+		assertSimpleType(t, datatypes.DoubleType, nil, gpa)
 
 		// Birthday
 		birthday := propNameToProp["birthday"]
-		assertSimpleType(t, instance.DateType, nil, birthday)
+		assertSimpleType(t, datatypes.DateType, nil, birthday)
 
 		// IsSolid
 		isSolid := propNameToProp["is_solid"]
-		assertSimpleType(t, instance.BooleanType, nil, isSolid)
+		assertSimpleType(t, datatypes.BooleanType, nil, isSolid)
 	}
 
 	// A record with no null property values
@@ -83,43 +84,43 @@ func TestReader_GetRecordsForModel(t *testing.T) {
 
 		// Name
 		name := propNameToProp["name"]
-		assertSimpleType(t, instance.StringType, "whatsit", name)
+		assertSimpleType(t, datatypes.StringType, "whatsit", name)
 
 		// ID
 		id := propNameToProp["id"]
-		assertSimpleType(t, instance.LongType, int64(57), id)
+		assertSimpleType(t, datatypes.LongType, int64(57), id)
 
 		// Weights
 		weights := propNameToProp["weights"]
-		assertArrayType(t, instance.ArrayDataType{
-			Type:  instance.ArrayType,
-			Items: instance.ItemsType{Type: instance.LongType},
+		assertArrayType(t, datatypes.ArrayDataType{
+			Type:  datatypes.ArrayType,
+			Items: datatypes.ItemsType{Type: datatypes.LongType},
 		}, []int64{3, 5, 7}, weights)
 
 		// Synonyms
 		synonyms := propNameToProp["synonyms"]
-		assertArrayType(t, instance.ArrayDataType{
-			Type:  instance.ArrayType,
-			Items: instance.ItemsType{Type: instance.StringType},
+		assertArrayType(t, datatypes.ArrayDataType{
+			Type:  datatypes.ArrayType,
+			Items: datatypes.ItemsType{Type: datatypes.StringType},
 		}, []string{"thingamabob", "whosit", "doo-dad"}, synonyms)
 
 		// GPA
 		gpa := propNameToProp["gpa"]
-		assertSimpleType(t, instance.DoubleType, 6.78, gpa)
+		assertSimpleType(t, datatypes.DoubleType, 6.78, gpa)
 
 		// Birthday
 		birthday := propNameToProp["birthday"]
 		require.NoError(t, err)
-		assertSimpleType(t, instance.DateType, "2024-09-26T22:01:04", birthday)
+		assertSimpleType(t, datatypes.DateType, "2024-09-26T22:01:04", birthday)
 
 		// IsSolid
 		isSolid := propNameToProp["is_solid"]
-		assertSimpleType(t, instance.BooleanType, "true", isSolid)
+		assertSimpleType(t, datatypes.BooleanType, "true", isSolid)
 	}
 
 }
 
-func assertSimpleType(t *testing.T, expectedType instance.SimpleType, expectedValue any, actualProperty instance.Property) bool {
+func assertSimpleType(t *testing.T, expectedType datatypes.SimpleType, expectedValue any, actualProperty instance.Property) bool {
 	dataType, err := actualProperty.DecodeDataType()
 	if !assert.NoError(t, err) {
 		return false
@@ -129,7 +130,7 @@ func assertSimpleType(t *testing.T, expectedType instance.SimpleType, expectedVa
 	}
 
 	actualValue := actualProperty.Value
-	if expectedType == instance.LongType {
+	if expectedType == datatypes.LongType {
 		actualValue, err = actualProperty.LongValue()
 		if !assert.NoError(t, err) {
 			return false
@@ -142,15 +143,15 @@ func assertSimpleType(t *testing.T, expectedType instance.SimpleType, expectedVa
 	return true
 }
 
-func assertArrayType(t *testing.T, expectedType instance.ArrayDataType, expectedValue any, actualProperty instance.Property) bool {
+func assertArrayType(t *testing.T, expectedType datatypes.ArrayDataType, expectedValue any, actualProperty instance.Property) bool {
 	dataType, err := actualProperty.DecodeDataType()
 	if !assert.NoError(t, err) {
 		return false
 	}
-	if !assert.IsType(t, instance.ArrayDataType{}, dataType) {
+	if !assert.IsType(t, datatypes.ArrayDataType{}, dataType) {
 		return false
 	}
-	actualDataType := dataType.(instance.ArrayDataType)
+	actualDataType := dataType.(datatypes.ArrayDataType)
 	if !assert.Equal(t, expectedType.Type, actualDataType.Type) {
 		return false
 	}


### PR DESCRIPTION
PR moves types that describe metadata datatypes out of the `instance` package and into their own package. These types can be used in both `instance` and `schema` types, so this move allows them to be shared.