### PR TITLE
Client Feature: Reading LinkedProperty instances from downloaded metadata

### DIFF
--- a/client/models/instance/link.go
+++ b/client/models/instance/link.go
@@ -1,0 +1,11 @@
+package instance
+
+type LinkedProperty struct {
+	DisplayName          string `json:"displayName"`
+	From                 string `json:"from"`
+	Id                   string `json:"id"`
+	Name                 string `json:"name"`
+	SchemaRelationshipId string `json:"schemaRelationshipId"`
+	To                   string `json:"to"`
+	Type                 string `json:"type"`
+}

--- a/client/models/schema/types.go
+++ b/client/models/schema/types.go
@@ -31,6 +31,10 @@ func (e Element) IsModel() bool {
 	return e.isType(string(ModelType))
 }
 
+func (e Element) IsLinkedProperty() bool {
+	return e.isType(string(LinkedPropertyType))
+}
+
 func ElementFromMap(jsonMap map[string]any) Element {
 	return Element{
 		ID:          jsonMap[IDKey].(string),

--- a/client/reader.go
+++ b/client/reader.go
@@ -13,16 +13,18 @@ import (
 
 // A Reader can be used to read the metadata records once they have been downloaded by the pre-processor
 type Reader struct {
-	MetadataDirectory          string
-	ModelNamesToSchemaElements map[string]schema.Element
+	MetadataDirectory               string
+	ModelNamesToSchemaElements      map[string]schema.Element
+	LinkedPropNamesToSchemaElements map[string]schema.Element
 }
 
 // NewReader returns a pointer to a new Reader instance. The rootDirectory argument should be
 // the parent directory of the metadata directory.
 func NewReader(rootDirectory string) (*Reader, error) {
 	reader := Reader{
-		MetadataDirectory:          filepath.Join(rootDirectory, paths.MetadataDirectory),
-		ModelNamesToSchemaElements: map[string]schema.Element{},
+		MetadataDirectory:               filepath.Join(rootDirectory, paths.MetadataDirectory),
+		ModelNamesToSchemaElements:      map[string]schema.Element{},
+		LinkedPropNamesToSchemaElements: map[string]schema.Element{},
 	}
 	schemaFilePath := filepath.Join(reader.MetadataDirectory, paths.SchemaFilePath)
 	schemaFile, err := os.Open(schemaFilePath)
@@ -38,6 +40,8 @@ func NewReader(rootDirectory string) (*Reader, error) {
 	for _, e := range elements {
 		if e.IsModel() {
 			reader.ModelNamesToSchemaElements[e.Name] = e
+		} else if e.IsLinkedProperty() {
+			reader.LinkedPropNamesToSchemaElements[e.Name] = e
 		}
 	}
 	return &reader, nil
@@ -52,10 +56,37 @@ func (r *Reader) GetRecordsForModel(modelName string) ([]instance.Record, error)
 	if err != nil {
 		return nil, fmt.Errorf("error opening records file %s for %s: %w", recordsFilePath, modelName, err)
 	}
+	defer recordsFile.Close()
 
 	var records []instance.Record
 	if err := json.NewDecoder(recordsFile).Decode(&records); err != nil {
 		return nil, fmt.Errorf("error decoding records file %s for %s: %w", recordsFilePath, modelName, err)
 	}
 	return records, nil
+}
+
+func (r *Reader) GetLinkInstancesForProperty(linkedPropertyName string) ([]instance.LinkedProperty, error) {
+	linkElement, isLink := r.LinkedPropNamesToSchemaElements[strings.ToLower(linkedPropertyName)]
+	if !isLink {
+		return nil, fmt.Errorf("linked property %s not found", linkedPropertyName)
+	}
+	linksFilePath := filepath.Join(r.MetadataDirectory, paths.LinkedPropertyInstancesFilePath(linkElement.ID))
+	linksFile, err := os.Open(linksFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening linked properties instance file %s for %s: %w",
+			linksFilePath,
+			linkedPropertyName,
+			err)
+	}
+	defer linksFile.Close()
+
+	var links []instance.LinkedProperty
+	if err := json.NewDecoder(linksFile).Decode(&links); err != nil {
+		return nil, fmt.Errorf("error decoding linked properties instance file %s for %s: %w",
+			linksFilePath,
+			linkedPropertyName,
+			err)
+	}
+	return links, nil
+
 }

--- a/client/reader_test.go
+++ b/client/reader_test.go
@@ -11,10 +11,13 @@ import (
 func TestNewReader(t *testing.T) {
 	reader, err := NewReader("testdata")
 	require.NoError(t, err)
+
 	assert.Len(t, reader.ModelNamesToSchemaElements, 3)
 	assert.Equal(t, "83964537-46d2-4fb5-9408-0b6262a42a56", reader.ModelNamesToSchemaElements["location"].ID)
 	assert.Equal(t, "bb04a8ce-03c9-4801-a0d9-e35cea53ac1b", reader.ModelNamesToSchemaElements["object"].ID)
 	assert.Equal(t, "7931cbe6-7494-4c0b-95f0-9f4b34edc73b", reader.ModelNamesToSchemaElements["subject"].ID)
+
+	assert.Len(t, reader.LinkedPropNamesToSchemaElements, 1)
 }
 
 func TestReader_GetRecordsForModel(t *testing.T) {
@@ -168,4 +171,26 @@ func assertArrayType(t *testing.T, expectedType datatypes.ArrayDataType, expecte
 		return false
 	}
 	return true
+}
+
+func TestReader_GetLinkInstancesForProperty(t *testing.T) {
+	reader, err := NewReader("testdata")
+	require.NoError(t, err)
+
+	links, err := reader.GetLinkInstancesForProperty("Address")
+	require.NoError(t, err)
+	assert.Len(t, links, 1)
+
+	linkInstance := links[0]
+	assert.Equal(t, "address", linkInstance.Name)
+	assert.Equal(t, "Address", linkInstance.DisplayName)
+
+	assert.Equal(t, "address", linkInstance.Type)
+
+	assert.Equal(t, "b7bcfc2b-a406-44d7-aeb8-09f440802b3a", linkInstance.Id)
+	assert.Equal(t, "bbea65fd-b51f-464a-a5d3-dc228ff408c1", linkInstance.SchemaRelationshipId)
+	assert.Equal(t, reader.LinkedPropNamesToSchemaElements["address"].ID, linkInstance.SchemaRelationshipId)
+
+	assert.Equal(t, "7681b4f8-7d10-4855-8c87-7fef3b408c0b", linkInstance.From)
+	assert.Equal(t, "e79e8d65-b094-4f36-94f2-1553cd84b4a2", linkInstance.To)
 }


### PR DESCRIPTION
Adds a map and method to `client.Reader` so that callers can request LinkedProperty instances for a given LinkedProperty name.