### PR TITLE
Handle Package Proxies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,10 +7,15 @@ layout relative to input directory:
 metadata/
 ├── schema/
 │   ├── graphSchema.json
+│   ├── relationships.json
 │   └── properties/
 │       ├── <model-id-1>.json
 │       └── <model-id-2>.json
 └── instances/
+    ├── proxies/
+    │   └── <model-id-1>/
+    │       ├── <record-id-1>.json
+    │       └── <record-id-2>.json
     ├── records/
     │   ├── <model-id-1>.json
     │   └── <model-id-2>.json

--- a/client/models/instance/proxy.go
+++ b/client/models/instance/proxy.go
@@ -1,0 +1,30 @@
+package instance
+
+import "time"
+
+type Proxy struct {
+	ProxyID
+	ProxyPackage
+}
+type ProxyID struct {
+	ID string `json:"id"`
+}
+
+type ProxyPackageContent struct {
+	CreatedAt     time.Time `json:"createdAt"`
+	DatasetId     string    `json:"datasetId"`
+	DatasetNodeId string    `json:"datasetNodeId"`
+	ID            string    `json:"id"`
+	Name          string    `json:"name"`
+	NodeID        string    `json:"nodeId"`
+	OwnerID       int       `json:"ownerId"`
+	PackageType   string    `json:"packageType"`
+	State         string    `json:"state"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}
+
+// ProxyPackage should also have "children" and "properties" slices, but we don't
+// need them for now
+type ProxyPackage struct {
+	Content ProxyPackageContent `json:"content"`
+}

--- a/client/models/instance/proxy.go
+++ b/client/models/instance/proxy.go
@@ -1,6 +1,9 @@
 package instance
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type Proxy struct {
 	ProxyID
@@ -28,3 +31,8 @@ type ProxyPackageContent struct {
 type ProxyPackage struct {
 	Content ProxyPackageContent `json:"content"`
 }
+
+// RawFromFile represents the structure of proxy instances as they appear in the downloaded files.
+// The first json.RawMessage is a ProxyID and the second is a ProxyPackage
+// A downloaded file will contain a []RawFromFile
+type RawFromFile [2]json.RawMessage

--- a/client/models/schema/proxy.go
+++ b/client/models/schema/proxy.go
@@ -1,0 +1,22 @@
+package schema
+
+const ProxyName = "belongs_to"
+const ProxyDisplayName = "Belongs To"
+
+// NullableRelationship represents an item in metadata/schema/relationships.json
+// where unlike a usual Relationship, the special proxy relationship will have "to" and "from" null.
+type NullableRelationship struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	DisplayName string  `json:"displayName"`
+	From        *string `json:"from"`
+	To          *string `json:"to"`
+}
+
+func (r NullableRelationship) IsProxy() bool {
+	return IsProxy(r)
+}
+
+func IsProxy(r NullableRelationship) bool {
+	return r.To == nil && r.From == nil && r.Name == ProxyName && r.DisplayName == ProxyDisplayName
+}

--- a/client/paths/paths.go
+++ b/client/paths/paths.go
@@ -82,7 +82,12 @@ func LinkedPropertyInstancesFilePath(schemaLinkedPropertyID string) string {
 	return filepath.Join(InstancesDirectory, LinkedPropertiesDirectory, fmt.Sprintf("%s.json", schemaLinkedPropertyID))
 }
 
-// ProxyInstancesFilePath the path of the instances file for the given record relative to the metadata directory
+// ProxyInstancesFilePath the path of the instances file for the given model and record relative to the metadata directory
 func ProxyInstancesFilePath(modelID, recordID string) string {
-	return filepath.Join(InstancesDirectory, ProxiesDirectory, modelID, fmt.Sprintf("%s.json", recordID))
+	return filepath.Join(ProxyInstancesForModelDirectory(modelID), fmt.Sprintf("%s.json", recordID))
+}
+
+// ProxyInstancesForModelDirectory the path (relative to the metadata directory) of the directory which contains the proxy instances files for the given modelID
+func ProxyInstancesForModelDirectory(modelID string) string {
+	return filepath.Join(InstancesDirectory, ProxiesDirectory, modelID)
 }

--- a/client/paths/paths.go
+++ b/client/paths/paths.go
@@ -9,10 +9,15 @@ import (
 // metadata/
 // ├── schema/
 // │   ├── graphSchema.json
+// │   ├── relationships.json
 // │   └── properties/
 // │       ├── <model-id-1>.json
 // │       └── <model-id-2>.json
 // └── instances/
+//     ├── proxies/
+//     │   └── <model-id-1>/
+//     │       ├── <record-id-1>.json
+//     │       └── <record-id-2>.json
 //     ├── records/
 //     │   ├── <model-id-1>.json
 //     │   └── <model-id-2>.json
@@ -44,6 +49,16 @@ const RelationshipsDirectory = "relationships"
 // LinkedPropertiesDirectory is the directory linked properties files will be placed in relative to the instances directory
 const LinkedPropertiesDirectory = "linkedProperties"
 
+// ProxiesDirectory is the directory proxy files will be placed in relative to the instances directory. It will contain
+// one file per record that has at least one package proxy
+const ProxiesDirectory = "proxies"
+
+// RelationshipSchemasFilePath is the path to the relations json file relative to the metadata directory.
+// Most of the info in this file will be in the SchemaFilePath file in another format. But this
+// will contain the special 'belongs_to' relation used by package proxies which is not included
+// in SchemaFilePath
+var RelationshipSchemasFilePath = filepath.Join(SchemaDirectory, "relationships.json")
+
 // SchemaFilePath is the path to the schema json file relative to the metadata directory
 var SchemaFilePath = filepath.Join(SchemaDirectory, "graphSchema.json")
 
@@ -65,4 +80,9 @@ func RelationshipInstancesFilePath(schemaRelationshipID string) string {
 // LinkedPropertyInstancesFilePath the path of the instances file for the given schema linked property relative to the metadata directory
 func LinkedPropertyInstancesFilePath(schemaLinkedPropertyID string) string {
 	return filepath.Join(InstancesDirectory, LinkedPropertiesDirectory, fmt.Sprintf("%s.json", schemaLinkedPropertyID))
+}
+
+// ProxyInstancesFilePath the path of the instances file for the given record relative to the metadata directory
+func ProxyInstancesFilePath(modelID, recordID string) string {
+	return filepath.Join(InstancesDirectory, ProxiesDirectory, modelID, fmt.Sprintf("%s.json", recordID))
 }

--- a/client/reader.go
+++ b/client/reader.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/pennsieve/processor-pre-metadata/client/models/instance"
 	"github.com/pennsieve/processor-pre-metadata/client/models/schema"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 )
 
 // A Reader can be used to read the metadata records once they have been downloaded by the pre-processor
@@ -60,8 +62,11 @@ func (r *Reader) GetRecordsForModel(modelName string) ([]instance.Record, error)
 	return records, nil
 }
 
+// GetProxiesForModel returns the proxy instances for the given model, grouped by the record IDs to which the proxies are linked.
+// That is, it returns a map from record ID to a slice of proxy instances for that record. Each proxy instance
+// represents one package that is linked to the record
 func (r *Reader) GetProxiesForModel(modelName string) (map[string][]instance.Proxy, error) {
-	_, isModel := r.Schema.ModelByName(modelName)
+	model, isModel := r.Schema.ModelByName(modelName)
 	if !isModel {
 		return nil, fmt.Errorf("model %s not found", modelName)
 	}
@@ -70,8 +75,66 @@ func (r *Reader) GetProxiesForModel(modelName string) (map[string][]instance.Pro
 		// If there is no Proxy schema, there should be no proxy instances
 		return proxiesByRecordID, nil
 	}
+	parentDirectoryPath := filepath.Join(r.MetadataDirectory, paths.ProxyInstancesForModelDirectory(model.ID))
+	dirEntries, err := os.ReadDir(parentDirectoryPath)
+	if err != nil {
+		// if the directory does not exist, this is not an error. Just means no proxy instances for this model
+		if errors.Is(err, os.ErrNotExist) {
+			return proxiesByRecordID, nil
+		} else {
+			return nil, fmt.Errorf("error reading proxy instance directory %s for model %s: %w", parentDirectoryPath, modelName, err)
+		}
+	}
+	for _, dirEntry := range dirEntries {
+		if recordID, isInstanceFile := getProxyRecordID(dirEntry); isInstanceFile {
+			instanceFilePath := filepath.Join(parentDirectoryPath, dirEntry.Name())
+			proxyInstances, err := readProxyInstanceFile(instanceFilePath)
+			if err != nil {
+				return nil, err
+			}
+			proxiesByRecordID[recordID] = proxyInstances
+		}
+	}
 	return proxiesByRecordID, nil
 
+}
+
+func getProxyRecordID(dirEntry os.DirEntry) (string, bool) {
+	extension := filepath.Ext(dirEntry.Name())
+	if dirEntry.Type().IsRegular() && extension == ".json" {
+		return strings.TrimSuffix(dirEntry.Name(), extension), true
+	}
+	return "", false
+}
+
+func readProxyInstanceFile(proxyInstanceFilePath string) ([]instance.Proxy, error) {
+	proxyInstanceFile, err := os.Open(proxyInstanceFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening proxy instance file %s: %w", proxyInstanceFilePath, err)
+	}
+	defer proxyInstanceFile.Close()
+
+	var rawInstances []instance.RawFromFile
+	if err := json.NewDecoder(proxyInstanceFile).Decode(&rawInstances); err != nil {
+		return nil, fmt.Errorf("error decoding proxy instances from file %s: %w", proxyInstanceFilePath, err)
+	}
+	var proxies []instance.Proxy
+	for _, raw := range rawInstances {
+		var proxyID instance.ProxyID
+		if err := json.Unmarshal(raw[0], &proxyID); err != nil {
+			return nil, fmt.Errorf("error decoding ProxyID %s from proxy instance file %s: %w", raw[0], proxyInstanceFilePath, err)
+		}
+		var proxyPackage instance.ProxyPackage
+		if err := json.Unmarshal(raw[1], &proxyPackage); err != nil {
+			return nil, fmt.Errorf("error decoding ProxyPackage %s from proxy instance file %s: %w", raw[1], proxyInstanceFilePath, err)
+		}
+		proxies = append(proxies, instance.Proxy{
+			ProxyID:      proxyID,
+			ProxyPackage: proxyPackage,
+		})
+	}
+
+	return proxies, nil
 }
 
 func (r *Reader) GetLinkInstancesForProperty(linkedPropertyName string) ([]instance.LinkedProperty, error) {

--- a/client/reader_test.go
+++ b/client/reader_test.go
@@ -24,6 +24,9 @@ func TestNewReader(t *testing.T) {
 		assert.Equal(t, expectedModelID, model.ID)
 	}
 	assert.Equal(t, 1, reader.Schema.LinkedPropertyCount())
+
+	assert.NotNil(t, reader.Schema.Proxy())
+	assert.Equal(t, "e18a8519-8368-4062-977a-60707c9c93ec", reader.Schema.Proxy().ID)
 }
 
 func TestReader_GetRecordsForModel(t *testing.T) {

--- a/client/reader_test.go
+++ b/client/reader_test.go
@@ -29,6 +29,56 @@ func TestNewReader(t *testing.T) {
 	assert.Equal(t, "e18a8519-8368-4062-977a-60707c9c93ec", reader.Schema.Proxy().ID)
 }
 
+func TestReader_GetProxiesForModel(t *testing.T) {
+	reader, err := NewReader("testdata")
+	require.NoError(t, err)
+
+	// location proxy instances
+	{
+		instancesByRecordID, err := reader.GetProxiesForModel("location")
+		require.NoError(t, err)
+
+		assert.Len(t, instancesByRecordID, 1)
+
+		assert.Contains(t, instancesByRecordID, "e79e8d65-b094-4f36-94f2-1553cd84b4a2")
+		instances := instancesByRecordID["e79e8d65-b094-4f36-94f2-1553cd84b4a2"]
+		assert.Len(t, instances, 1)
+
+		assert.Equal(t, "a6752c89-83d9-4191-8806-d55956e3217c", instances[0].ID)
+		assert.Equal(t, "N:collection:e3c0abb8-7480-42af-9529-99cafe9ea235", instances[0].Content.NodeID)
+	}
+
+	//object proxy instances
+	{
+		instancesByRecordID, err := reader.GetProxiesForModel("object")
+		require.NoError(t, err)
+
+		assert.Len(t, instancesByRecordID, 2)
+
+		assert.Contains(t, instancesByRecordID, "a9b9d03b-19b3-4a43-b40e-5673ec955e49")
+		instances1 := instancesByRecordID["a9b9d03b-19b3-4a43-b40e-5673ec955e49"]
+		assert.Len(t, instances1, 1)
+
+		assert.Equal(t, "6baa77da-9760-4deb-8a19-c97c3286a259", instances1[0].ID)
+		assert.Equal(t, "N:collection:95bb7c19-0e8e-42b2-b53f-f5ce7a08e42a", instances1[0].Content.NodeID)
+
+		assert.Contains(t, instancesByRecordID, "bcf06e0c-42dc-4ce9-9c70-9ee6865ebc7c")
+		instances2 := instancesByRecordID["bcf06e0c-42dc-4ce9-9c70-9ee6865ebc7c"]
+		assert.Len(t, instances2, 1)
+
+		assert.Equal(t, "15bebbdc-e479-462f-b094-043a29cecfc9", instances2[0].ID)
+		assert.Equal(t, "N:package:f90ff4bc-e3e5-4a53-b545-158ea770fbd8", instances2[0].Content.NodeID)
+	}
+
+	//subject proxy instances
+	{
+		instancesByRecordID, err := reader.GetProxiesForModel("subject")
+		require.NoError(t, err)
+
+		assert.Empty(t, instancesByRecordID)
+	}
+}
+
 func TestReader_GetRecordsForModel(t *testing.T) {
 	reader, err := NewReader("testdata")
 	require.NoError(t, err)

--- a/client/schema.go
+++ b/client/schema.go
@@ -5,9 +5,10 @@ import "github.com/pennsieve/processor-pre-metadata/client/models/schema"
 type Schema struct {
 	modelNamesToSchemaElements      map[string]schema.Element
 	linkedPropNamesToSchemaElements map[string]schema.Element
+	proxy                           *schema.NullableRelationship
 }
 
-func NewSchema(schemaElements []schema.Element) *Schema {
+func NewSchema(schemaElements []schema.Element, proxy *schema.NullableRelationship) *Schema {
 	modelMap := make(map[string]schema.Element)
 	linkMap := make(map[string]schema.Element)
 	for _, e := range schemaElements {
@@ -20,6 +21,7 @@ func NewSchema(schemaElements []schema.Element) *Schema {
 	return &Schema{
 		modelNamesToSchemaElements:      modelMap,
 		linkedPropNamesToSchemaElements: linkMap,
+		proxy:                           proxy,
 	}
 }
 
@@ -39,4 +41,8 @@ func (s *Schema) LinkedPropertyCount() int {
 func (s *Schema) LinkedPropertyByName(linkName string) (linkedProperty schema.Element, linkedPropertyExists bool) {
 	linkedProperty, linkedPropertyExists = s.linkedPropNamesToSchemaElements[linkName]
 	return
+}
+
+func (s *Schema) Proxy() *schema.NullableRelationship {
+	return s.proxy
 }

--- a/client/testdata/metadata/instances/proxies/83964537-46d2-4fb5-9408-0b6262a42a56/e79e8d65-b094-4f36-94f2-1553cd84b4a2.json
+++ b/client/testdata/metadata/instances/proxies/83964537-46d2-4fb5-9408-0b6262a42a56/e79e8d65-b094-4f36-94f2-1553cd84b4a2.json
@@ -1,0 +1,23 @@
+[
+  [
+    {
+      "id": "a6752c89-83d9-4191-8806-d55956e3217c"
+    },
+    {
+      "children": [],
+      "content": {
+        "createdAt": "2024-10-03T03:08:04.527432Z",
+        "datasetId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "datasetNodeId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "id": "N:collection:e3c0abb8-7480-42af-9529-99cafe9ea235",
+        "name": "location",
+        "nodeId": "N:collection:e3c0abb8-7480-42af-9529-99cafe9ea235",
+        "ownerId": 172,
+        "packageType": "Collection",
+        "state": "READY",
+        "updatedAt": "2024-10-03T03:08:04.527432Z"
+      },
+      "properties": []
+    }
+  ]
+]

--- a/client/testdata/metadata/instances/proxies/bb04a8ce-03c9-4801-a0d9-e35cea53ac1b/a9b9d03b-19b3-4a43-b40e-5673ec955e49.json
+++ b/client/testdata/metadata/instances/proxies/bb04a8ce-03c9-4801-a0d9-e35cea53ac1b/a9b9d03b-19b3-4a43-b40e-5673ec955e49.json
@@ -1,0 +1,23 @@
+[
+  [
+    {
+      "id": "6baa77da-9760-4deb-8a19-c97c3286a259"
+    },
+    {
+      "children": [],
+      "content": {
+        "createdAt": "2024-10-03T03:06:51.76978Z",
+        "datasetId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "datasetNodeId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "id": "N:collection:95bb7c19-0e8e-42b2-b53f-f5ce7a08e42a",
+        "name": "object",
+        "nodeId": "N:collection:95bb7c19-0e8e-42b2-b53f-f5ce7a08e42a",
+        "ownerId": 172,
+        "packageType": "Collection",
+        "state": "READY",
+        "updatedAt": "2024-10-03T03:06:51.76978Z"
+      },
+      "properties": []
+    }
+  ]
+]

--- a/client/testdata/metadata/instances/proxies/bb04a8ce-03c9-4801-a0d9-e35cea53ac1b/bcf06e0c-42dc-4ce9-9c70-9ee6865ebc7c.json
+++ b/client/testdata/metadata/instances/proxies/bb04a8ce-03c9-4801-a0d9-e35cea53ac1b/bcf06e0c-42dc-4ce9-9c70-9ee6865ebc7c.json
@@ -1,0 +1,46 @@
+[
+  [
+    {
+      "id": "15bebbdc-e479-462f-b094-043a29cecfc9"
+    },
+    {
+      "children": [],
+      "content": {
+        "createdAt": "2024-06-13T19:34:52.724091Z",
+        "datasetId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "datasetNodeId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "id": "N:package:f90ff4bc-e3e5-4a53-b545-158ea770fbd8",
+        "name": "log.txt",
+        "nodeId": "N:package:f90ff4bc-e3e5-4a53-b545-158ea770fbd8",
+        "ownerId": 172,
+        "packageType": "Text",
+        "state": "READY",
+        "updatedAt": "2024-06-13T19:34:52.724091Z"
+      },
+      "properties": [
+        {
+          "category": "Pennsieve",
+          "properties": [
+            {
+              "dataType": "string",
+              "display": "Text",
+              "fixed": false,
+              "hidden": true,
+              "key": "subtype",
+              "value": "Text"
+            },
+            {
+              "dataType": "string",
+              "display": "Text",
+              "fixed": false,
+              "hidden": true,
+              "key": "icon",
+              "value": "Text"
+            }
+          ]
+        }
+      ],
+      "storage": 485
+    }
+  ]
+]

--- a/client/testdata/metadata/schema/relationships.json
+++ b/client/testdata/metadata/schema/relationships.json
@@ -1,0 +1,41 @@
+[
+  {
+    "createdAt": "2024-06-13T20:15:02.748000+00:00",
+    "createdBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42",
+    "description": "",
+    "displayName": "Has Been At",
+    "from": "bb04a8ce-03c9-4801-a0d9-e35cea53ac1b",
+    "id": "30e7861f-ebae-4cf8-b9bc-2d6b1ae6008d",
+    "name": "has_been_at_9de740e0-29c1-11ef-bd79-2da515dfdab1",
+    "schema": [],
+    "to": "83964537-46d2-4fb5-9408-0b6262a42a56",
+    "updatedAt": "2024-06-13T20:15:02.748000+00:00",
+    "updatedBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42"
+  },
+  {
+    "createdAt": "2024-06-13T19:30:38.815000+00:00",
+    "createdBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42",
+    "description": "",
+    "displayName": "Beholds",
+    "from": "7931cbe6-7494-4c0b-95f0-9f4b34edc73b",
+    "id": "2514a023-17fe-4743-af5f-094ed3dd339c",
+    "name": "beholds_6a012da0-29bb-11ef-a8a5-6d16b0d3d9a0",
+    "schema": [],
+    "to": "bb04a8ce-03c9-4801-a0d9-e35cea53ac1b",
+    "updatedAt": "2024-06-13T19:30:38.815000+00:00",
+    "updatedBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42"
+  },
+  {
+    "createdAt": "2024-10-11T02:25:44.199000+00:00",
+    "createdBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42",
+    "description": "",
+    "displayName": "Belongs To",
+    "from": null,
+    "id": "e18a8519-8368-4062-977a-60707c9c93ec",
+    "name": "belongs_to",
+    "schema": [],
+    "to": null,
+    "updatedAt": "2024-10-11T02:25:44.199000+00:00",
+    "updatedBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42"
+  }
+]

--- a/service/pennsieve/proxies.go
+++ b/service/pennsieve/proxies.go
@@ -1,0 +1,25 @@
+package pennsieve
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pennsieve/processor-pre-metadata/service/util"
+	"net/http"
+)
+
+// GetProxyInstancesForRecord returns an []any because we are only dumping result to a file if there are any
+// proxies. So all we care about here is if the slice is empty or not.
+func (s *Session) GetProxyInstancesForRecord(datasetID, modelID, recordID string) ([]any, error) {
+	url := fmt.Sprintf("%s/models/datasets/%s/concepts/%s/instances/%s/files", s.APIHost, datasetID, modelID, recordID)
+	res, err := s.InvokePennsieve(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer util.CloseAndWarn(res)
+
+	var proxies []any
+	if err := json.NewDecoder(res.Body).Decode(&proxies); err != nil {
+		return nil, fmt.Errorf("error decoding proxies for record %s: %w", recordID, err)
+	}
+	return proxies, nil
+}

--- a/service/pennsieve/relationships.go
+++ b/service/pennsieve/relationships.go
@@ -9,3 +9,8 @@ func (s *Session) GetRelationshipInstances(datasetID, schemaRelationshipID strin
 	url := fmt.Sprintf("%s/models/v1/datasets/%s/relationships/%s/instances", s.APIHost, datasetID, schemaRelationshipID)
 	return s.InvokePennsieve(http.MethodGet, url, nil)
 }
+
+func (s *Session) GetRelationshipSchemas(datasetID string) (*http.Response, error) {
+	url := fmt.Sprintf("%s/models/datasets/%s/relationships", s.APIHost, datasetID)
+	return s.InvokePennsieve(http.MethodGet, url, nil)
+}

--- a/service/preprocessor/paths.go
+++ b/service/preprocessor/paths.go
@@ -32,12 +32,17 @@ func (m *MetadataPreProcessor) LinkedPropertiesPath() string {
 	return filepath.Join(m.MetadataPath(), paths.InstancesDirectory, paths.LinkedPropertiesDirectory)
 }
 
+// ProxiesPath gives the path to proxiesDirectory relative to the input directory
+func (m *MetadataPreProcessor) ProxiesPath() string {
+	return filepath.Join(m.MetadataPath(), paths.InstancesDirectory, paths.ProxiesDirectory)
+}
 func (m *MetadataPreProcessor) MkDirectories() error {
 	leafDirectories := []string{
 		m.PropertiesPath(),
 		m.RecordsPath(),
 		m.RelationshipsPath(),
 		m.LinkedPropertiesPath(),
+		m.ProxiesPath(),
 	}
 	for _, leaf := range leafDirectories {
 		if err := os.MkdirAll(leaf, 0755); err != nil {

--- a/service/preprocessor/preprocessor_test.go
+++ b/service/preprocessor/preprocessor_test.go
@@ -33,7 +33,13 @@ func TestRun(t *testing.T) {
 		"2514a023-17fe-4743-af5f-094ed3dd339c",
 	).WithSchemaLinkedProperties(
 		"bbea65fd-b51f-464a-a5d3-dc228ff408c1",
-	).Build(t)
+	).WithProxies(map[string][]string{
+		"83964537-46d2-4fb5-9408-0b6262a42a56": {"e79e8d65-b094-4f36-94f2-1553cd84b4a2"},
+		"bb04a8ce-03c9-4801-a0d9-e35cea53ac1b": {"a9b9d03b-19b3-4a43-b40e-5673ec955e49", "bcf06e0c-42dc-4ce9-9c70-9ee6865ebc7c"}},
+	).WithNoProxies(map[string][]string{
+		"7931cbe6-7494-4c0b-95f0-9f4b34edc73b": {"7681b4f8-7d10-4855-8c87-7fef3b408c0b"},
+		"bb04a8ce-03c9-4801-a0d9-e35cea53ac1b": {"5b07e038-9829-46c9-b698-bf4efef81341"},
+	}).Build(t)
 	mockServer := newMockServer(t, integrationID, datasetId, expectedFiles)
 	defer mockServer.Close()
 
@@ -50,8 +56,9 @@ type ExpectedFile struct {
 	Bytes        []byte
 	Content      any
 	// APIPath is the request path the mock server will match against.
-	APIPath     string
-	QueryParams url.Values
+	APIPath             string
+	QueryParams         url.Values
+	ExpectFileNotExists bool
 }
 
 func (e ExpectedFile) HandlerFunc(t *testing.T) func(http.ResponseWriter, *http.Request) {
@@ -73,7 +80,10 @@ type ExpectedFiles struct {
 func NewExpectedFiles(datasetID string) *ExpectedFiles {
 	return &ExpectedFiles{
 		DatasetID: datasetID,
-		Files:     []ExpectedFile{{TestdataPath: paths.SchemaFilePath, APIPath: fmt.Sprintf("/models/v1/datasets/%s/concepts/schema/graph", datasetID)}},
+		Files: []ExpectedFile{
+			{TestdataPath: paths.SchemaFilePath, APIPath: fmt.Sprintf("/models/v1/datasets/%s/concepts/schema/graph", datasetID)},
+			{TestdataPath: paths.RelationshipSchemasFilePath, APIPath: fmt.Sprintf("/models/datasets/%s/relationships", datasetID)},
+		},
 	}
 }
 
@@ -111,14 +121,42 @@ func (e *ExpectedFiles) WithSchemaLinkedProperties(schemaLinkedPropertyIDs ...st
 	return e
 }
 
+func (e *ExpectedFiles) WithProxies(modelIDToRecordIDs map[string][]string) *ExpectedFiles {
+	for modelID, recordIDs := range modelIDToRecordIDs {
+		for _, recordID := range recordIDs {
+			e.Files = append(e.Files, ExpectedFile{
+				TestdataPath: paths.ProxyInstancesFilePath(modelID, recordID),
+				APIPath:      fmt.Sprintf("/models/datasets/%s/concepts/%s/instances/%s/files", e.DatasetID, modelID, recordID),
+			})
+		}
+	}
+	return e
+}
+
+func (e *ExpectedFiles) WithNoProxies(modelIDToRecordIDs map[string][]string) *ExpectedFiles {
+	for modelID, recordIDs := range modelIDToRecordIDs {
+		for _, recordID := range recordIDs {
+			e.Files = append(e.Files, ExpectedFile{
+				TestdataPath:        paths.ProxyInstancesFilePath(modelID, recordID),
+				APIPath:             fmt.Sprintf("/models/datasets/%s/concepts/%s/instances/%s/files", e.DatasetID, modelID, recordID),
+				Bytes:               json.RawMessage("[]"),
+				ExpectFileNotExists: true,
+			})
+		}
+	}
+	return e
+}
+
 func (e *ExpectedFiles) Build(t *testing.T) *ExpectedFiles {
 	for i := range e.Files {
 		expected := &e.Files[i]
-		file := filepath.Join("testdata", expected.TestdataPath)
-		bytes, err := os.ReadFile(file)
-		require.NoError(t, err)
-		expected.Bytes = bytes
-		require.NoError(t, json.Unmarshal(bytes, &expected.Content))
+		if !expected.ExpectFileNotExists {
+			file := filepath.Join("testdata", expected.TestdataPath)
+			bytes, err := os.ReadFile(file)
+			require.NoError(t, err)
+			expected.Bytes = bytes
+			require.NoError(t, json.Unmarshal(bytes, &expected.Content))
+		}
 	}
 	return e
 }
@@ -126,11 +164,17 @@ func (e *ExpectedFiles) Build(t *testing.T) *ExpectedFiles {
 func (e *ExpectedFiles) AssertEqual(t *testing.T, actualDir string) {
 	for _, expectedFile := range e.Files {
 		actualFilePath := filepath.Join(actualDir, expectedFile.TestdataPath)
-		actualBytes, err := os.ReadFile(actualFilePath)
-		if assert.NoError(t, err) {
-			var actualContent any
-			require.NoError(t, json.Unmarshal(actualBytes, &actualContent))
-			assert.Equal(t, expectedFile.Content, actualContent, "actual content %s does not match expected content %s", actualFilePath, expectedFile.TestdataPath)
+		if expectedFile.ExpectFileNotExists {
+			assert.NoFileExists(t, actualFilePath)
+		} else {
+			actualBytes, err := os.ReadFile(actualFilePath)
+			if assert.NoError(t, err) {
+				// Comparing content, not bytes, since checked in expected files may be JSON formatted, while response
+				// from mock server is not, making the []bytes unequal.
+				var actualContent any
+				require.NoError(t, json.Unmarshal(actualBytes, &actualContent))
+				assert.Equal(t, expectedFile.Content, actualContent, "actual content %s does not match expected content %s", actualFilePath, expectedFile.TestdataPath)
+			}
 		}
 	}
 }

--- a/service/preprocessor/testdata/instances/proxies/83964537-46d2-4fb5-9408-0b6262a42a56/e79e8d65-b094-4f36-94f2-1553cd84b4a2.json
+++ b/service/preprocessor/testdata/instances/proxies/83964537-46d2-4fb5-9408-0b6262a42a56/e79e8d65-b094-4f36-94f2-1553cd84b4a2.json
@@ -1,0 +1,23 @@
+[
+  [
+    {
+      "id": "a6752c89-83d9-4191-8806-d55956e3217c"
+    },
+    {
+      "children": [],
+      "content": {
+        "createdAt": "2024-10-03T03:08:04.527432Z",
+        "datasetId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "datasetNodeId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "id": "N:collection:e3c0abb8-7480-42af-9529-99cafe9ea235",
+        "name": "location",
+        "nodeId": "N:collection:e3c0abb8-7480-42af-9529-99cafe9ea235",
+        "ownerId": 172,
+        "packageType": "Collection",
+        "state": "READY",
+        "updatedAt": "2024-10-03T03:08:04.527432Z"
+      },
+      "properties": []
+    }
+  ]
+]

--- a/service/preprocessor/testdata/instances/proxies/bb04a8ce-03c9-4801-a0d9-e35cea53ac1b/a9b9d03b-19b3-4a43-b40e-5673ec955e49.json
+++ b/service/preprocessor/testdata/instances/proxies/bb04a8ce-03c9-4801-a0d9-e35cea53ac1b/a9b9d03b-19b3-4a43-b40e-5673ec955e49.json
@@ -1,0 +1,23 @@
+[
+  [
+    {
+      "id": "6baa77da-9760-4deb-8a19-c97c3286a259"
+    },
+    {
+      "children": [],
+      "content": {
+        "createdAt": "2024-10-03T03:06:51.76978Z",
+        "datasetId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "datasetNodeId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "id": "N:collection:95bb7c19-0e8e-42b2-b53f-f5ce7a08e42a",
+        "name": "object",
+        "nodeId": "N:collection:95bb7c19-0e8e-42b2-b53f-f5ce7a08e42a",
+        "ownerId": 172,
+        "packageType": "Collection",
+        "state": "READY",
+        "updatedAt": "2024-10-03T03:06:51.76978Z"
+      },
+      "properties": []
+    }
+  ]
+]

--- a/service/preprocessor/testdata/instances/proxies/bb04a8ce-03c9-4801-a0d9-e35cea53ac1b/bcf06e0c-42dc-4ce9-9c70-9ee6865ebc7c.json
+++ b/service/preprocessor/testdata/instances/proxies/bb04a8ce-03c9-4801-a0d9-e35cea53ac1b/bcf06e0c-42dc-4ce9-9c70-9ee6865ebc7c.json
@@ -1,0 +1,46 @@
+[
+  [
+    {
+      "id": "15bebbdc-e479-462f-b094-043a29cecfc9"
+    },
+    {
+      "children": [],
+      "content": {
+        "createdAt": "2024-06-13T19:34:52.724091Z",
+        "datasetId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "datasetNodeId": "N:dataset:e323328c-13c3-44f3-aaff-4fd5a941ded5",
+        "id": "N:package:f90ff4bc-e3e5-4a53-b545-158ea770fbd8",
+        "name": "log.txt",
+        "nodeId": "N:package:f90ff4bc-e3e5-4a53-b545-158ea770fbd8",
+        "ownerId": 172,
+        "packageType": "Text",
+        "state": "READY",
+        "updatedAt": "2024-06-13T19:34:52.724091Z"
+      },
+      "properties": [
+        {
+          "category": "Pennsieve",
+          "properties": [
+            {
+              "dataType": "string",
+              "display": "Text",
+              "fixed": false,
+              "hidden": true,
+              "key": "subtype",
+              "value": "Text"
+            },
+            {
+              "dataType": "string",
+              "display": "Text",
+              "fixed": false,
+              "hidden": true,
+              "key": "icon",
+              "value": "Text"
+            }
+          ]
+        }
+      ],
+      "storage": 485
+    }
+  ]
+]

--- a/service/preprocessor/testdata/schema/relationships.json
+++ b/service/preprocessor/testdata/schema/relationships.json
@@ -1,0 +1,41 @@
+[
+  {
+    "createdAt": "2024-06-13T20:15:02.748000+00:00",
+    "createdBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42",
+    "description": "",
+    "displayName": "Has Been At",
+    "from": "bb04a8ce-03c9-4801-a0d9-e35cea53ac1b",
+    "id": "30e7861f-ebae-4cf8-b9bc-2d6b1ae6008d",
+    "name": "has_been_at_9de740e0-29c1-11ef-bd79-2da515dfdab1",
+    "schema": [],
+    "to": "83964537-46d2-4fb5-9408-0b6262a42a56",
+    "updatedAt": "2024-06-13T20:15:02.748000+00:00",
+    "updatedBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42"
+  },
+  {
+    "createdAt": "2024-06-13T19:30:38.815000+00:00",
+    "createdBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42",
+    "description": "",
+    "displayName": "Beholds",
+    "from": "7931cbe6-7494-4c0b-95f0-9f4b34edc73b",
+    "id": "2514a023-17fe-4743-af5f-094ed3dd339c",
+    "name": "beholds_6a012da0-29bb-11ef-a8a5-6d16b0d3d9a0",
+    "schema": [],
+    "to": "bb04a8ce-03c9-4801-a0d9-e35cea53ac1b",
+    "updatedAt": "2024-06-13T19:30:38.815000+00:00",
+    "updatedBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42"
+  },
+  {
+    "createdAt": "2024-10-11T02:25:44.199000+00:00",
+    "createdBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42",
+    "description": "",
+    "displayName": "Belongs To",
+    "from": null,
+    "id": "e18a8519-8368-4062-977a-60707c9c93ec",
+    "name": "belongs_to",
+    "schema": [],
+    "to": null,
+    "updatedAt": "2024-10-11T02:25:44.199000+00:00",
+    "updatedBy": "N:user:a6f827dc-46e0-487c-9e19-ffe7dda54b42"
+  }
+]


### PR DESCRIPTION
PR adds handling of packages that are linked to records via proxies.

On the service side, we now download relationships so that the special proxy relationship can be seen in the schema if it exists. We also check each record for linked package proxies.

On the client side, a new method is added to `Reader` so that packages linked to model records can be read.