### PR TITLE
Use current pseudo version string for client in service

### DIFF
--- a/service/go.mod
+++ b/service/go.mod
@@ -6,7 +6,7 @@ replace github.com/pennsieve/processor-pre-metadata/client => ./../client
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/pennsieve/processor-pre-metadata/client v0.0.0
+	github.com/pennsieve/processor-pre-metadata/client v0.0.0-20241015190912-3e004748369b
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Replace non-existent version string with an up-to-date one.