### PR TITLE
Use client tag in service

### DIFF
--- a/service/go.mod
+++ b/service/go.mod
@@ -6,7 +6,7 @@ replace github.com/pennsieve/processor-pre-metadata/client => ./../client
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/pennsieve/processor-pre-metadata/client v0.0.0-20241015190912-3e004748369b
+	github.com/pennsieve/processor-pre-metadata/client v0.0.0
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Use the client/v0.0.0 tag in service so that the ttl sync pre-processor can get a real version