### PR TITLE
Don't need /v1/ when calling model service

### DIFF
--- a/service/pennsieve/models.go
+++ b/service/pennsieve/models.go
@@ -6,12 +6,12 @@ import (
 )
 
 func (s *Session) GetGraphSchema(datasetID string) (*http.Response, error) {
-	url := fmt.Sprintf("%s/models/v1/datasets/%s/concepts/schema/graph", s.APIHost, datasetID)
+	url := fmt.Sprintf("%s/models/datasets/%s/concepts/schema/graph", s.APIHost, datasetID)
 
 	return s.InvokePennsieve(http.MethodGet, url, nil)
 }
 
 func (s *Session) GetProperties(datasetID, modelID string) (*http.Response, error) {
-	url := fmt.Sprintf("%s/models/v1/datasets/%s/concepts/%s/properties", s.APIHost, datasetID, modelID)
+	url := fmt.Sprintf("%s/models/datasets/%s/concepts/%s/properties", s.APIHost, datasetID, modelID)
 	return s.InvokePennsieve(http.MethodGet, url, nil)
 }

--- a/service/pennsieve/records.go
+++ b/service/pennsieve/records.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *Session) GetRecordsPage(datasetID string, modelID string, limit int, offset int) ([]map[string]any, error) {
-	url := fmt.Sprintf("%s/models/v1/datasets/%s/concepts/%s/instances?limit=%d&offset=%d", s.APIHost, datasetID, modelID, limit, offset)
+	url := fmt.Sprintf("%s/models/datasets/%s/concepts/%s/instances?limit=%d&offset=%d", s.APIHost, datasetID, modelID, limit, offset)
 	res, err := s.InvokePennsieve(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err

--- a/service/pennsieve/relationships.go
+++ b/service/pennsieve/relationships.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *Session) GetRelationshipInstances(datasetID, schemaRelationshipID string) (*http.Response, error) {
-	url := fmt.Sprintf("%s/models/v1/datasets/%s/relationships/%s/instances", s.APIHost, datasetID, schemaRelationshipID)
+	url := fmt.Sprintf("%s/models/datasets/%s/relationships/%s/instances", s.APIHost, datasetID, schemaRelationshipID)
 	return s.InvokePennsieve(http.MethodGet, url, nil)
 }
 

--- a/service/preprocessor/preprocessor_test.go
+++ b/service/preprocessor/preprocessor_test.go
@@ -81,7 +81,7 @@ func NewExpectedFiles(datasetID string) *ExpectedFiles {
 	return &ExpectedFiles{
 		DatasetID: datasetID,
 		Files: []ExpectedFile{
-			{TestdataPath: paths.SchemaFilePath, APIPath: fmt.Sprintf("/models/v1/datasets/%s/concepts/schema/graph", datasetID)},
+			{TestdataPath: paths.SchemaFilePath, APIPath: fmt.Sprintf("/models/datasets/%s/concepts/schema/graph", datasetID)},
 			{TestdataPath: paths.RelationshipSchemasFilePath, APIPath: fmt.Sprintf("/models/datasets/%s/relationships", datasetID)},
 		},
 	}
@@ -91,10 +91,10 @@ func (e *ExpectedFiles) WithModels(modelIDs ...string) *ExpectedFiles {
 	for _, modelID := range modelIDs {
 		e.Files = append(e.Files, ExpectedFile{
 			TestdataPath: paths.PropertiesFilePath(modelID),
-			APIPath:      fmt.Sprintf("/models/v1/datasets/%s/concepts/%s/properties", e.DatasetID, modelID),
+			APIPath:      fmt.Sprintf("/models/datasets/%s/concepts/%s/properties", e.DatasetID, modelID),
 		}, ExpectedFile{
 			TestdataPath: paths.RecordsFilePath(modelID),
-			APIPath:      fmt.Sprintf("/models/v1/datasets/%s/concepts/%s/instances", e.DatasetID, modelID),
+			APIPath:      fmt.Sprintf("/models/datasets/%s/concepts/%s/instances", e.DatasetID, modelID),
 			QueryParams:  map[string][]string{"limit": {strconv.Itoa(defaultRecordsBatchSize)}, "offset": {strconv.Itoa(0)}},
 		})
 	}
@@ -105,7 +105,7 @@ func (e *ExpectedFiles) WithSchemaRelationships(schemaRelationshipsIDs ...string
 	for _, schemaRelationshipID := range schemaRelationshipsIDs {
 		e.Files = append(e.Files, ExpectedFile{
 			TestdataPath: paths.RelationshipInstancesFilePath(schemaRelationshipID),
-			APIPath:      fmt.Sprintf("/models/v1/datasets/%s/relationships/%s/instances", e.DatasetID, schemaRelationshipID),
+			APIPath:      fmt.Sprintf("/models/datasets/%s/relationships/%s/instances", e.DatasetID, schemaRelationshipID),
 		})
 	}
 	return e
@@ -115,7 +115,7 @@ func (e *ExpectedFiles) WithSchemaLinkedProperties(schemaLinkedPropertyIDs ...st
 	for _, schemaLinkedPropertyID := range schemaLinkedPropertyIDs {
 		e.Files = append(e.Files, ExpectedFile{
 			TestdataPath: paths.LinkedPropertyInstancesFilePath(schemaLinkedPropertyID),
-			APIPath:      fmt.Sprintf("/models/v1/datasets/%s/relationships/%s/instances", e.DatasetID, schemaLinkedPropertyID),
+			APIPath:      fmt.Sprintf("/models/datasets/%s/relationships/%s/instances", e.DatasetID, schemaLinkedPropertyID),
 		})
 	}
 	return e


### PR DESCRIPTION
Gets rid of the `/v1/` in model service urls. They are not needed.