### PR TITLE
Fix log format

### DIFF
--- a/service/pennsieve/invoke.go
+++ b/service/pennsieve/invoke.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/pennsieve/processor-pre-metadata/service/logging"
 	"io"
+	"log/slog"
 	"net/http"
 )
 
@@ -46,7 +47,10 @@ func (s *Session) InvokePennsieve(method string, url string, body io.Reader) (*h
 	if err := checkHTTPStatus(res); err != nil {
 		// if there was an error, checkHTTPStatus read the body
 		if closeError := res.Body.Close(); closeError != nil {
-			logger.Warn("error closing response body from %s %s: %w", method, url, closeError)
+			logger.Warn("error closing body from http status error",
+				slog.String("method", method),
+				slog.String("url", url),
+				slog.Any("error", closeError))
 		}
 		return nil, err
 	}

--- a/service/util/http.go
+++ b/service/util/http.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"github.com/pennsieve/processor-pre-metadata/service/logging"
+	"log/slog"
 	"net/http"
 )
 
@@ -9,6 +10,9 @@ var logger = logging.PackageLogger("util")
 
 func CloseAndWarn(response *http.Response) {
 	if err := response.Body.Close(); err != nil {
-		logger.Warn("error closing response body from %s %s: %w", response.Request.Method, response.Request.URL, err)
+		logger.Warn("error closing response body",
+			slog.String("method", response.Request.Method),
+			slog.String("url", response.Request.URL.String()),
+			slog.Any("error", err))
 	}
 }


### PR DESCRIPTION
Fixes some logging that was mistakenly using `Sprintf` type formatting instead of the correct `slog.Attr`s.